### PR TITLE
Node v0.3.8

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -77,14 +77,14 @@ Request.prototype.executeRequest= function(method, arguments, sign_it, result_ma
         argumentString+= (operator + key + "=" + arguments[key]);
         if( operator == "?" ) operator= "&";
     }
-    
+   
     var request= this.getHttpClient().request("GET", 
                           this.baseUrl+ argumentString, 
                           {"host": "api.flickr.com"});
     var isFeedRequest= this.isFeedRequest;          
     request.addListener('response', function (response) {
         var result= "";
-        response.setBodyEncoding("utf8");
+        response.setEncoding("utf8");
         response.addListener("data", function (chunk) {
           result+= chunk;
         });
@@ -129,7 +129,7 @@ Request.prototype.executeRequest= function(method, arguments, sign_it, result_ma
             }
         });
     });       
-    request.close();
+    request.end();
 };
 
 exports.Request = Request;


### PR DESCRIPTION
I'm not sure what version of node changed the http.ClientResponseAPI, but I had to do two simple changes to get it to work with v0.3.8.
